### PR TITLE
Fixes #11: Path to procfs is not configurable

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -9,59 +9,80 @@
 			"Rev": "cd7d1bbe41066b6c1f19780f895901052150a575"
 		},
 		{
+			"ImportPath": "github.com/intelsdi-x/snap-plugin-utilities/config",
+			"Rev": "04621af7a3979bcb8aaf08c3b6542b43fe0bf6cf"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap-plugin-utilities/ns",
+			"Rev": "04621af7a3979bcb8aaf08c3b6542b43fe0bf6cf"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap-plugin-utilities/str",
+			"Rev": "04621af7a3979bcb8aaf08c3b6542b43fe0bf6cf"
+		},
+		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/cpolicy",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encoding",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encrypter",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/cdata",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/ctypes",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/serror",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/ctree",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/schedule",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/scheduler/wmap",
-			"Comment": "v0.13.0-beta-79-ga579d11",
-			"Rev": "a579d11b579d8bf521ffc51ae3416e84543d209c"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+		},
+		{
+			"ImportPath": "github.com/mitchellh/mapstructure",
+			"Rev": "281073eb9eb092240d33ef253c404f1cca550309"
+		},
+		{
+			"ImportPath": "github.com/oleiade/reflections",
+			"Comment": "0.1.2-2-g632977f",
+			"Rev": "632977f98cd34d217c4b57d0840ec188b3d3dcaf"
 		},
 		{
 			"ImportPath": "github.com/robfig/cron",

--- a/main.go
+++ b/main.go
@@ -30,7 +30,6 @@ import (
 
 func main() {
 	plugin.Start(
-		plugin.NewPluginMeta(mem.PLUGIN, mem.VERSION, plugin.CollectorPluginType, []string{}, []string{plugin.SnapGOBContentType},
-			plugin.ConcurrencyCount(1)), mem.New(), os.Args[1],
+		mem.Meta(), mem.New(), os.Args[1],
 	)
 }

--- a/mem/mem.go
+++ b/mem/mem.go
@@ -23,6 +23,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -90,7 +91,7 @@ func (mp *memPlugin) GetMetricTypes(cfg plugin.ConfigType) ([]plugin.MetricType,
 func (mp *memPlugin) CollectMetrics(metricTypes []plugin.MetricType) ([]plugin.MetricType, error) {
 	metrics := []plugin.MetricType{}
 
-	pathMemInfo, err := config.GetConfigItem(metricTypes[0], "procfs_path")
+	pathMemInfo, err := config.GetConfigItem(metricTypes[0], "proc_path")
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +121,7 @@ func (mp *memPlugin) CollectMetrics(metricTypes []plugin.MetricType) ([]plugin.M
 // It returns error in case retrieval was not successful
 func (mp *memPlugin) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
 	cp := cpolicy.New()
-	rule, _ := cpolicy.NewStringRule("procfs_path", false, "/proc/meminfo")
+	rule, _ := cpolicy.NewStringRule("proc_path", false, "/proc")
 	node := cpolicy.NewPolicyNode()
 	node.Add(rule)
 	cp.Add([]string{pluginVendor, fs, pluginName}, node)
@@ -131,8 +132,8 @@ type memPlugin struct {
 	logger *log.Logger
 }
 
-func getStats(pathMemInfo string, metrics *MemMetrics) error {
-	fh, err := os.Open(pathMemInfo)
+func getStats(procPath string, metrics *MemMetrics) error {
+	fh, err := os.Open(path.Join(procPath, "meminfo"))
 
 	if err != nil {
 		return err

--- a/mem/mem_test.go
+++ b/mem/mem_test.go
@@ -40,22 +40,21 @@ type GetStatsSuite struct {
 }
 
 func (gss *GetStatsSuite) SetupSuite() {
-	gss.MockMemInfo = "mockMemInfo"
 	gss.tot = 1200
 	gss.buf = 500
 	gss.cache = 300
 	gss.free = 100
 	gss.slab = 100
 	gss.used = gss.tot - (gss.free + gss.buf + gss.cache + gss.slab)
-	createMockMemInfo(gss.MockMemInfo, gss.tot, gss.buf, gss.cache, gss.free, gss.slab)
+	createMockMemInfo("meminfo", gss.tot, gss.buf, gss.cache, gss.free, gss.slab)
 }
 
 func (gss *GetStatsSuite) TearDownSuite() {
-	removeMockMemInfo(gss.MockMemInfo)
+	removeMockMemInfo("meminfo")
 }
 
 func TestGetStatsSuite(t *testing.T) {
-	suite.Run(t, &GetStatsSuite{MockMemInfo: "mockMemInfo"})
+	suite.Run(t, &GetStatsSuite{MockMemInfo: "."})
 }
 
 func (gss *GetStatsSuite) TestGetStats() {
@@ -63,7 +62,7 @@ func (gss *GetStatsSuite) TestGetStats() {
 		stats := &MemMetrics{}
 
 		Convey("and mock memory info file created", func() {
-			assert.Equal(gss.T(), "mockMemInfo", gss.MockMemInfo)
+			assert.Equal(gss.T(), ".", gss.MockMemInfo)
 		})
 
 		Convey("When reading memory statistics from file", func() {
@@ -92,18 +91,17 @@ type MemPluginSuite struct {
 }
 
 func (mps *MemPluginSuite) TearDownSuite() {
-	removeMockMemInfo(mps.MockMemInfo)
+	removeMockMemInfo("meminfo")
 }
 
 func (mps *MemPluginSuite) SetupSuite() {
-	mps.MockMemInfo = "mockMemInfo"
 	mps.tot = 2000
 	mps.buf = 500
 	mps.cache = 300
 	mps.free = 100
 	mps.slab = 100
 	mps.used = mps.tot - (mps.free + mps.buf + mps.cache + mps.slab)
-	createMockMemInfo(mps.MockMemInfo, mps.tot, mps.buf, mps.cache, mps.free, mps.slab)
+	createMockMemInfo("meminfo", mps.tot, mps.buf, mps.cache, mps.free, mps.slab)
 
 }
 
@@ -113,7 +111,7 @@ func (mps *MemPluginSuite) TestGetMetricTypes() {
 
 		Convey("When one wants to get list of available meterics", func() {
 			cfg := plugin.NewPluginConfigType()
-			cfg.AddItem("procfs_path", ctypes.ConfigValueStr{mps.MockMemInfo})
+			cfg.AddItem("proc_path", ctypes.ConfigValueStr{mps.MockMemInfo})
 			mts, err := memPlugin.GetMetricTypes(cfg)
 
 			Convey("Then error should not be reported", func() {
@@ -151,7 +149,7 @@ func (mps *MemPluginSuite) TestCollectMetrics() {
 
 		Convey("When one wants to get values for given metric types", func() {
 			cfg := plugin.NewPluginConfigType()
-			cfg.AddItem("procfs_path", ctypes.ConfigValueStr{mps.MockMemInfo})
+			cfg.AddItem("proc_path", ctypes.ConfigValueStr{mps.MockMemInfo})
 			mTypes := []plugin.MetricType{
 				plugin.MetricType{Namespace_: core.NewNamespace("intel", "procfs", "meminfo", "cached"), Config_: cfg.ConfigDataNode},
 				plugin.MetricType{Namespace_: core.NewNamespace("intel", "procfs", "meminfo", "cached_perc"), Config_: cfg.ConfigDataNode},
@@ -187,7 +185,7 @@ func (mps *MemPluginSuite) TestCollectMetrics() {
 }
 
 func TestMemPluginSuite(t *testing.T) {
-	suite.Run(t, &MemPluginSuite{MockMemInfo: "mockMemInfo"})
+	suite.Run(t, &MemPluginSuite{MockMemInfo: "."})
 }
 
 func createMockMemInfo(memInfo string, tot, buf, cache, free, slab uint64) {

--- a/mem/metrics.go
+++ b/mem/metrics.go
@@ -1,0 +1,132 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015-2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mem
+
+type MemMetrics struct {
+	MemTotal          uint64 `json:"mem_total" mapstructure:"mem_total"`
+	MemUsed           uint64 `json:"mem_used" mapstructure:"mem_used"`
+	MemFree           uint64 `json:"mem_free" mapstructure:"mem_free"`
+	MemAvailable      uint64 `json:"mem_available" mapstructure:"mem_available"`
+	Buffers           uint64 `json:"buffers" mapstructure:"buffers"`
+	Cached            uint64 `json:"cached" mapstructure:"cached"`
+	SwapCached        uint64 `json:"swap_cached" mapstructure:"swap_cached"`
+	Active            uint64 `json:"active" mapstructure:"active"`
+	Inactive          uint64 `json:"inactive" mapstructure:"inactive"`
+	ActiveAnon        uint64 `json:"active_anon" mapstructure:"active_anon"`
+	InactiveAnon      uint64 `json:"inactive_anon" mapstructure:"inactive_anon"`
+	ActiveFile        uint64 `json:"active_file" mapstructure:"active_file"`
+	InactiveFile      uint64 `json:"inactive_file" mapstructure:"inactive_file"`
+	Unevictable       uint64 `json:"unevictable" mapstructure:"unevictable"`
+	Mlocked           uint64 `json:"mlocked" mapstructure:"mlocked"`
+	HighTotal         uint64 `json:"high_total" mapstructure:"high_total"`
+	HighFree          uint64 `json:"high_free" mapstructure:"high_free"`
+	LowTotal          uint64 `json:"low_total" mapstructure:"low_total"`
+	LowFree           uint64 `json:"low_free" mapstructure:"low_free"`
+	MmapCopy          uint64 `json:"mmap_copy" mapstructure:"mmap_copy"`
+	SwapTotal         uint64 `json:"swap_total" mapstructure:"swap_total"`
+	SwapFree          uint64 `json:"swap_free" mapstructure:"swap_free"`
+	Dirty             uint64 `json:"dirty" mapstructure:"dirty"`
+	Writeback         uint64 `json:"writeback" mapstructure:"writeback"`
+	AnonPages         uint64 `json:"anon_pages" mapstructure:"anon_pages"`
+	Mapped            uint64 `json:"mapped" mapstructure:"mapped"`
+	Shmem             uint64 `json:"shmem" mapstructure:"shmem"`
+	Slab              uint64 `json:"slab" mapstructure:"slab"`
+	SReclaimable      uint64 `json:"sreclaimable" mapstructure:"sreclaimable"`
+	SUnreclaim        uint64 `json:"sunreclaim" mapstructure:"sunreclaim"`
+	KernelStack       uint64 `json:"kernel_stack" mapstructure:"kernel_stack"`
+	PageTables        uint64 `json:"page_tables" mapstructure:"page_tables"`
+	Quicklists        uint64 `json:"quicklists" mapstructure:"quicklists"`
+	NFSUnstable       uint64 `json:"nfs_unstable" mapstructure:"nfs_unstable"`
+	Bounce            uint64 `json:"bounce" mapstructure:"bounce"`
+	WritebackTmp      uint64 `json:"writeback_tmp" mapstructure:"writeback_tmp"`
+	CommitLimit       uint64 `json:"commit_limit" mapstructure:"commit_limit"`
+	CommittedAS       uint64 `json:"committed_as" mapstructure:"committed_as"`
+	VmallocTotal      uint64 `json:"vmalloc_total" mapstructure:"vmalloc_total"`
+	VmallocUsed       uint64 `json:"vmalloc_used" mapstructure:"vmalloc_used"`
+	VmallocChunk      uint64 `json:"vmalloc_chunk" mapstructure:"vmalloc_chunk"`
+	HardwareCorrupted uint64 `json:"hardware_corrupted" mapstructure:"hardware_corrupted"`
+	AnonHugePages     uint64 `json:"anon_huge_pages" mapstructure:"anon_huge_pages"`
+	CmaTotal          uint64 `json:"cma_total" mapstructure:"cma_total"`
+	CmaFree           uint64 `json:"cma_free" mapstructure:"cma_free"`
+	HugePagesTotal    uint64 `json:"huge_pages_total" mapstructure:"huge_pages_total"`
+	HugePagesFree     uint64 `json:"huge_pages_free" mapstructure:"huge_pages_free"`
+	HugePagesRsvd     uint64 `json:"huge_pages_rsvd" mapstructure:"huge_pages_rsvd"`
+	HugePagesSurp     uint64 `json:"huge_pages_surp" mapstructure:"huge_pages_surp"`
+	Hugepagesize      uint64 `json:"hugepagesize" mapstructure:"hugepagesize"`
+	DirectMap4k       uint64 `json:"direct_map4k" mapstructure:"direct_map4k"`
+	DirectMap4M       uint64 `json:"direct_map4m" mapstructure:"direct_map4m"`
+	DirectMap2M       uint64 `json:"direct_map2m" mapstructure:"direct_map2m"`
+	DirectMap1G       uint64 `json:"direct_map1g" mapstructure:"direct_map1g"`
+
+	MemTotalPerc          float64 `json:"mem_total_perc" mapstructure:"mem_total_perc"`
+	MemUsedPerc           float64 `json:"mem_used_perc" mapstructure:"mem_used_perc"`
+	MemFreePerc           float64 `json:"mem_free_perc" mapstructure:"mem_free_perc"`
+	MemAvailablePerc      float64 `json:"mem_available_perc" mapstructure:"mem_available_perc"`
+	BuffersPerc           float64 `json:"buffers_perc" mapstructure:"buffers_perc"`
+	CachedPerc            float64 `json:"cached_perc" mapstructure:"cached_perc"`
+	SwapCachedPerc        float64 `json:"swap_cached_perc" mapstructure:"swap_cached_perc"`
+	ActivePerc            float64 `json:"active_perc" mapstructure:"active_perc"`
+	InactivePerc          float64 `json:"inactive_perc" mapstructure:"inactive_perc"`
+	ActiveAnonPerc        float64 `json:"active_anon_perc" mapstructure:"active_anon_perc"`
+	InactiveAnonPerc      float64 `json:"inactive_anon_perc" mapstructure:"inactive_anon_perc"`
+	ActiveFilePerc        float64 `json:"active_file_perc" mapstructure:"active_file_perc"`
+	InactiveFilePerc      float64 `json:"inactive_file_perc" mapstructure:"inactive_file_perc"`
+	UnevictablePerc       float64 `json:"unevictable_perc" mapstructure:"unevictable_perc"`
+	MlockedPerc           float64 `json:"mlocked_perc" mapstructure:"mlocked_perc"`
+	HighTotalPerc         float64 `json:"high_total_perc" mapstructure:"high_total_perc"`
+	HighFreePerc          float64 `json:"high_free_perc" mapstructure:"high_free_perc"`
+	LowTotalPerc          float64 `json:"low_total_perc" mapstructure:"low_total_perc"`
+	LowFreePerc           float64 `json:"low_free_perc" mapstructure:"low_free_perc"`
+	MmapCopyPerc          float64 `json:"mmap_copy_perc" mapstructure:"mmap_copy_perc"`
+	SwapTotalPerc         float64 `json:"swap_total_perc" mapstructure:"swap_total_perc"`
+	SwapFreePerc          float64 `json:"swap_free_perc" mapstructure:"swap_free_perc"`
+	DirtyPerc             float64 `json:"dirty_perc" mapstructure:"dirty_perc"`
+	WritebackPerc         float64 `json:"writeback_perc" mapstructure:"writeback_perc"`
+	AnonPagesPerc         float64 `json:"anon_pages_perc" mapstructure:"anon_pages_perc"`
+	MappedPerc            float64 `json:"mapped_perc" mapstructure:"mapped_perc"`
+	ShmemPerc             float64 `json:"shmem_perc" mapstructure:"shmem_perc"`
+	SlabPerc              float64 `json:"slab_perc" mapstructure:"slab_perc"`
+	SReclaimablePerc      float64 `json:"sreclaimable_perc" mapstructure:"sreclaimable_perc"`
+	SUnreclaimPerc        float64 `json:"sunreclaim_perc" mapstructure:"sunreclaim_perc"`
+	KernelStackPerc       float64 `json:"kernel_stack_perc" mapstructure:"kernel_stack_perc"`
+	PageTablesPerc        float64 `json:"page_tables_perc" mapstructure:"page_tables_perc"`
+	QuicklistsPerc        float64 `json:"quicklists_perc" mapstructure:"quicklists_perc"`
+	NFSUnstablePerc       float64 `json:"nfs_unstable_perc" mapstructure:"nfs_unstable_perc"`
+	BouncePerc            float64 `json:"bounce_perc" mapstructure:"bounce_perc"`
+	WritebackTmpPerc      float64 `json:"writeback_tmp_perc" mapstructure:"writeback_tmp_perc"`
+	CommitLimitPerc       float64 `json:"commit_limit_perc" mapstructure:"commit_limit_perc"`
+	CommittedASPerc       float64 `json:"committed_as_perc" mapstructure:"committed_as_perc"`
+	VmallocTotalPerc      float64 `json:"vmalloc_total_perc" mapstructure:"vmalloc_total_perc"`
+	VmallocUsedPerc       float64 `json:"vmalloc_used_perc" mapstructure:"vmalloc_used_perc"`
+	VmallocChunkPerc      float64 `json:"vmalloc_chunk_perc" mapstructure:"vmalloc_chunk_perc"`
+	HardwareCorruptedPerc float64 `json:"hardware_corrupted_perc" mapstructure:"hardware_corrupted_perc"`
+	AnonHugePagesPerc     float64 `json:"anon_huge_pages_perc" mapstructure:"anon_huge_pages_perc"`
+	CmaTotalPerc          float64 `json:"cma_total_perc" mapstructure:"cma_total_perc"`
+	CmaFreePerc           float64 `json:"cma_free_perc" mapstructure:"cma_free_perc"`
+	HugePagesTotalPerc    float64 `json:"huge_pages_total_perc" mapstructure:"huge_pages_total_perc"`
+	HugePagesFreePerc     float64 `json:"huge_pages_free_perc" mapstructure:"huge_pages_free_perc"`
+	HugePagesRsvdPerc     float64 `json:"huge_pages_rsvd_perc" mapstructure:"huge_pages_rsvd_perc"`
+	HugePagesSurpPerc     float64 `json:"huge_pages_surp_perc" mapstructure:"huge_pages_surp_perc"`
+	HugepagesizePerc      float64 `json:"hugepagesize_perc" mapstructure:"hugepagesize_perc"`
+	DirectMap4kPerc       float64 `json:"direct_map4k_perc" mapstructure:"direct_map4k_perc"`
+	DirectMap4MPerc       float64 `json:"direct_map4m_perc" mapstructure:"direct_map4m_perc"`
+	DirectMap2MPerc       float64 `json:"direct_map2m_perc" mapstructure:"direct_map2m_perc"`
+	DirectMap1GPerc       float64 `json:"direct_map1g_perc" mapstructure:"direct_map1g_perc"`
+}


### PR DESCRIPTION
- procfs/meminfo path is configurable via task manifest
- defaults to /proc/meminfo
- static construction of metric catalog
- updated tests and dependencies