### PR TITLE
Submodule removed, updated to large tests, glide.lock

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "scripts/test/pytest"]
-	path = scripts/test/pytest
-	url = https://github.com/marcin-krolik/snap-pytest

--- a/examples/tasks/.setup.sh
+++ b/examples/tasks/.setup.sh
@@ -4,8 +4,6 @@ set -e
 set -u
 set -o pipefail
 
-git submodule update --init --recursive
-
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # check for dependencies

--- a/examples/tasks/docker-compose.yml
+++ b/examples/tasks/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   main:
     container_name: runner
-    image: intelsdi/snap:alpine
+    image: mkrolik/snap-pytest
     environment:
      - SNAP_VERSION=latest
     volumes:

--- a/examples/tasks/mock-meminfo.sh
+++ b/examples/tasks/mock-meminfo.sh
@@ -16,7 +16,7 @@ PLUGIN_PATH=${PLUGIN_PATH:-"${TMPDIR}/snap/plugins"}
 mkdir -p $PLUGIN_PATH
 
 _info "downloading plugins"
-(cd $PLUGIN_PATH && curl -sfLSO http://snap.ci.snap-telemetry.io/snap/master/latest/snap-plugin-publisher-mock-file && chmod 755 snap-plugin-publisher-mock-file)
+(cd $PLUGIN_PATH && curl -sfLSO http://snap.ci.snap-telemetry.io/snap/latest_build/linux/x86_64/snap-plugin-publisher-mock-file && chmod 755 snap-plugin-publisher-mock-file)
 (cd $PLUGIN_PATH && curl -sfLSO http://snap.ci.snap-telemetry.io/plugins/snap-plugin-collector-meminfo/latest_build/linux/x86_64/snap-plugin-collector-meminfo && chmod 755 snap-plugin-collector-meminfo)
 
 SNAP_FLAG=0

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,69 @@
+hash: a5d8527edddbfd61a438bac8ebb8cfc1686f6fe81e3b03eded68d413819ea1ec
+updated: 2016-10-12T14:13:51.127712295+02:00
+imports:
+- name: github.com/intelsdi-x/snap
+  version: 14a1611e90f4f94d690e85c6ae58d81a5cf433d0
+  subpackages:
+  - control/plugin
+  - control/plugin/cpolicy
+  - control/plugin/encoding
+  - control/plugin/encrypter
+  - core
+  - core/cdata
+  - core/ctypes
+  - core/serror
+  - pkg/ctree
+  - pkg/schedule
+  - scheduler/wmap
+- name: github.com/intelsdi-x/snap-plugin-utilities
+  version: 925bafffac36edcfaf4aff937dcb7d3d5659782d
+  subpackages:
+  - config
+  - ns
+  - str
+- name: github.com/mitchellh/mapstructure
+  version: a6ef2f080c66d0a2e94e97cf74f80f772855da63
+- name: github.com/oleiade/reflections
+  version: 632977f98cd34d217c4b57d0840ec188b3d3dcaf
+- name: github.com/robfig/cron
+  version: 32d9c273155a0506d27cf73dd1246e86a470997e
+- name: github.com/Sirupsen/logrus
+  version: be52937128b38f1d99787bb476c789e2af1147f1
+- name: golang.org/x/sys
+  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  subpackages:
+  - unix
+- name: gopkg.in/yaml.v2
+  version: c1cd2254a6dd314c9d73c338c12688c9325d85c6
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  subpackages:
+  - spew
+- name: github.com/gopherjs/gopherjs
+  version: 4b53e1bddba0e2f734514aeb6c02db652f4c6fe8
+  subpackages:
+  - js
+- name: github.com/jtolds/gls
+  version: 8ddce2a84170772b95dd5d576c48d517b22cac63
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/smartystreets/assertions
+  version: 443d812296a84445c202c085f19e18fc238f8250
+  subpackages:
+  - internal/go-render/render
+  - internal/oglematchers
+- name: github.com/smartystreets/goconvey
+  version: 995f5b2e021c69b8b028ba6d0b05c1dd500783db
+  subpackages:
+  - convey
+  - convey/gotest
+  - convey/reporting
+- name: github.com/stretchr/testify
+  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
+  subpackages:
+  - assert
+  - require
+  - suite

--- a/scripts/docker/large/docker-compose.yml
+++ b/scripts/docker/large/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   main:
     container_name: meminfo_large_test
-    image: python:2.7.12-alpine
+    image: mkrolik/spytest
     network_mode: "host"
     volumes:
       - ${PLUGIN_SRC}:/${PROJECT_NAME}

--- a/scripts/large_compose.sh
+++ b/scripts/large_compose.sh
@@ -41,9 +41,6 @@ _docker_project () {
   cd "${docker_folder}" && "$@"
 }
 
-_debug "updating repository submodule with pytest"
-git submodule update --init --recursive
-
 _debug "building docker compose images"
 _docker_project docker-compose build
 _debug "running test: ${TEST_TYPE}"

--- a/scripts/large_test.sh
+++ b/scripts/large_test.sh
@@ -27,9 +27,6 @@ __proj_name="$(basename $__proj_dir)"
 
 . "${__dir}/common.sh"
 
-_info "updating repository submodule with pytest"
-cd ${__proj_dir} && git submodule update --init --recursive
-
 export PROJECT_DIR="${__proj_dir}"
 
 _info "execute large test"

--- a/scripts/test/large.py
+++ b/scripts/test/large.py
@@ -19,9 +19,9 @@ import sys
 import os
 import unittest
 
-from pytest import bins
-from pytest import utils
-from pytest.logger import log
+from spytest import bins
+from spytest import utils
+from spytest.logger import log
 from unittest import TextTestRunner
 
 
@@ -30,10 +30,10 @@ class MemInfoCollectorLargeTest(unittest.TestCase):
         plugins_dir = os.getenv("PLUGINS_DIR", "/etc/snap/plugins")
         snap_dir = os.getenv("SNAP_DIR", "/usr/local/bin")
 
-        snapd_url = "http://snap.ci.snap-telemetry.io/snap/master/latest/snapd"
-        snapctl_url = "http://snap.ci.snap-telemetry.io/snap/master/latest/snapctl"
+        snapd_url = "http://snap.ci.snap-telemetry.io/snap/latest_build/linux/x86_64/snapd"
+        snapctl_url = "http://snap.ci.snap-telemetry.io/snap/latest_build/linux/x86_64/snapctl"
         meminfo_url = "http://snap.ci.snap-telemetry.io/plugins/snap-plugin-collector-meminfo/latest_build/linux/x86_64/snap-plugin-collector-meminfo"
-        mockfile_url = "http://snap.ci.snap-telemetry.io/snap/master/latest/snap-plugin-publisher-mock-file"
+        mockfile_url = "http://snap.ci.snap-telemetry.io/snap/latest_build/linux/x86_64/snap-plugin-publisher-mock-file"
 
         # set and download required binaries (snapd, snapctl, plugins)
         self.binaries = bins.Binaries()


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Summary of changes:
- removed submodule repo
- added `glide.lock`
- `spytest` pip package used in large tests
- path to S3 binaries updated

How to verify it:
- large tests
- run example

Testing done:
- large tests

