### PR TITLE
Updated snapd/snapctl to snapteld/snaptel in doc and large tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ This builds the plugin in `./build`
 ### Configuration and Usage
 * Set up the [Snap framework](https://github.com/intelsdi-x/snap/blob/master/README.md#getting-started)
 
-* If /proc resides in a different directory, say for example by mounting host /proc inside a container at /hostproc, a proc_path configuration item can be added to snapd global config or as part of the task manifest for the metrics to be collected.
+* If /proc resides in a different directory, say for example by mounting host /proc inside a container at /hostproc, a proc_path configuration item can be added to snapteld global config or as part of the task manifest for the metrics to be collected.
 
-As part of snapd global config
+As part of snapteld global config
 
 ```yaml
 ---
@@ -96,20 +96,20 @@ Set up the [Snap framework](https://github.com/intelsdi-x/snap/blob/master/READM
 Ensure [Snap daemon is running](https://github.com/intelsdi-x/snap#running-snap):
 * initd: `service snap-telemetry start`
 * systemd: `systemctl start snap-telemetry`
-* command line: `sudo snapd -l 1 -t 0 &`
+* command line: `sudo snapteld -l 1 -t 0 &`
 
 
 Download and load Snap plugins:
 ```
 $ wget http://snap.ci.snap-telemetry.io/plugins/snap-plugin-publisher-file/latest/linux/x86_64/snap-plugin-publisher-file
 $ wget http://snap.ci.snap-telemetry.io/plugins/snap-plugin-collector-meminfo/latest/linux/x86_64/snap-plugin-collector-meminfo
-$ snapctl plugin load snap-plugin-publisher-file
-$ snapctl plugin load snap-plugin-collector-meminfo
+$ snaptel plugin load snap-plugin-publisher-file
+$ snaptel plugin load snap-plugin-collector-meminfo
 ```
 
 See available metrics for your system
 ```
-$ snapctl metric list
+$ snaptel metric list
 ```
 
 Create a [task manifest](https://github.com/intelsdi-x/snap/blob/master/docs/TASKS.md) (see [exemplary tasks](examples/tasks/)),
@@ -149,17 +149,17 @@ for example `meminfo-file.json` with following content:
 
 Create a task:
 ```
-$ snapctl task create -t meminfo-file.json
+$ snaptel task create -t meminfo-file.json
 ```
 
 Watch created task:
 ```
-$ snapctl task watch <task_id>
+$ snaptel task watch <task_id>
 ```
 
 To stop previously created task:
 ```
-$ snapctl task stop <task_id>
+$ snaptel task stop <task_id>
 ```
 
 ### Roadmap

--- a/examples/tasks/.setup.sh
+++ b/examples/tasks/.setup.sh
@@ -15,7 +15,7 @@ if [[ $EXIT_ON_ERROR > 0 ]]; then
     exit 1
 fi
 
-# start container with snapd
+# start container with snapteld
 (cd $__dir && docker-compose up -d)
 
 # clean up containers on exit

--- a/examples/tasks/README.md
+++ b/examples/tasks/README.md
@@ -12,7 +12,7 @@ Running the sample is as *easy* as running the script `./run-mock-meminfo.sh`.
 
 ## Files
 - [mock-meminfo.sh](mock-meminfo.sh)
-    - Downloads `snapd`, `snapctl`, `snap-plugin-collector-meminfo`,
+    - Downloads `snapteld`, `snaptel`, `snap-plugin-collector-meminfo`,
         `snap-plugin-publisher-mock-file` and starts the task
 - [run-mock-meminfo.sh](run-mock-meminfo.sh)
     - The example is launched with this script     
@@ -22,6 +22,6 @@ Running the sample is as *easy* as running the script `./run-mock-meminfo.sh`.
     - Verifies dependencies and starts the containers.  It's called 
     by [run-mock-meminfo.sh](run-mock-meminfo.sh).
 - [docker-compose.yml](docker-compose.yml)
-    - A docker compose file which defines "runner" container where snapd
+    - A docker compose file which defines "runner" container where snapteld
      is run from. You will be dumped into a shell in this container
      after running.    

--- a/examples/tasks/mock-meminfo.sh
+++ b/examples/tasks/mock-meminfo.sh
@@ -21,31 +21,31 @@ _info "downloading plugins"
 
 SNAP_FLAG=0
 
-# this block will wait check if snapctl and snapd are loaded before the plugins are loaded and the task is started
+# this block will wait check if snaptel and snapteld are loaded before the plugins are loaded and the task is started
  for i in `seq 1 10`; do
             _info "try ${i}"
-             if [[ -f /usr/local/bin/snapctl && -f /usr/local/bin/snapd ]];
+             if [[ -f /usr/local/bin/snaptel && -f /usr/local/sbin/snapteld ]];
                 then
                     _info "loading plugins"
-                    snapctl plugin load "${PLUGIN_PATH}/snap-plugin-publisher-mock-file"
-                    snapctl plugin load "${PLUGIN_PATH}/snap-plugin-collector-meminfo"
+                    snaptel plugin load "${PLUGIN_PATH}/snap-plugin-publisher-mock-file"
+                    snaptel plugin load "${PLUGIN_PATH}/snap-plugin-collector-meminfo"
 
                     _info "creating and starting a task"
-                    snapctl task create -t "${__dir}/task-mem.json"
+                    snaptel task create -t "${__dir}/task-mem.json"
 
                     SNAP_FLAG=1
 
                     break
              fi 
         
-        _info "snapctl and/or snapd are unavailable, sleeping for 5 seconds"
+        _info "snaptel and/or snapteld are unavailable, sleeping for 5 seconds"
         sleep 5
 done 
 
 
-# check if snapctl/snapd have loaded
+# check if snaptel/snapteld have loaded
 if [ $SNAP_FLAG -eq 0 ]
     then
-     echo "Could not load snapctl or snapd"
+     echo "Could not load snaptel or snapteld"
      exit 1
 fi

--- a/examples/tasks/run-mock-meminfo.sh
+++ b/examples/tasks/run-mock-meminfo.sh
@@ -15,4 +15,4 @@ export PLUGIN_SRC="${__proj_dir}"
 . "${__proj_dir}/examples/tasks/.setup.sh"
 
 # downloads plugins, starts snap, load plugins and start a task
-cd "${__proj_dir}/examples/tasks" && docker-compose exec main bash -c "PLUGIN_PATH=/etc/snap/plugins /${__proj_name}/examples/tasks/mock-meminfo.sh && printf \"\n\nhint: type 'snapctl task list'\ntype 'exit' when your done\n\n\" && bash"
+cd "${__proj_dir}/examples/tasks" && docker-compose exec main bash -c "PLUGIN_PATH=/etc/snap/plugins /${__proj_name}/examples/tasks/mock-meminfo.sh && printf \"\n\nhint: type 'snaptel task list'\ntype 'exit' when your done\n\n\" && bash"

--- a/examples/tasks/task-mem.json
+++ b/examples/tasks/task-mem.json
@@ -19,7 +19,7 @@
       },
       "publish": [
         {
-          "plugin_name": "file",
+          "plugin_name": "mock-file",
           "config": {
             "file": "/tmp/published_meminfo.log"
           }

--- a/scripts/test/large.py
+++ b/scripts/test/large.py
@@ -28,17 +28,18 @@ from unittest import TextTestRunner
 class MemInfoCollectorLargeTest(unittest.TestCase):
     def setUp(self):
         plugins_dir = os.getenv("PLUGINS_DIR", "/etc/snap/plugins")
-        snap_dir = os.getenv("SNAP_DIR", "/usr/local/bin")
+        snapteld_dir = os.getenv("SNAPTELD_DIR", "/usr/local/sbin")
+        snaptel_dir = os.getenv("SNAPTEL_DIR", "/usr/local/bin")
 
-        snapd_url = "http://snap.ci.snap-telemetry.io/snap/latest_build/linux/x86_64/snapd"
-        snapctl_url = "http://snap.ci.snap-telemetry.io/snap/latest_build/linux/x86_64/snapctl"
+        snapteld_url = "http://snap.ci.snap-telemetry.io/snap/latest_build/linux/x86_64/snapteld"
+        snaptel_url = "http://snap.ci.snap-telemetry.io/snap/latest_build/linux/x86_64/snaptel"
         meminfo_url = "http://snap.ci.snap-telemetry.io/plugins/snap-plugin-collector-meminfo/latest_build/linux/x86_64/snap-plugin-collector-meminfo"
         mockfile_url = "http://snap.ci.snap-telemetry.io/snap/latest_build/linux/x86_64/snap-plugin-publisher-mock-file"
 
-        # set and download required binaries (snapd, snapctl, plugins)
+        # set and download required binaries (snapteld, snaptel, plugins)
         self.binaries = bins.Binaries()
-        self.binaries.snapd = bins.Snapd(snapd_url, snap_dir)
-        self.binaries.snapctl = bins.Snapctl(snapctl_url, snap_dir)
+        self.binaries.snapteld = bins.Snapteld(snapteld_url, snapteld_dir)
+        self.binaries.snaptel = bins.Snaptel(snaptel_url, snaptel_dir)
         self.binaries.collector = bins.Plugin(meminfo_url, plugins_dir, "collector", 3)
         self.binaries.publisher = bins.Plugin(mockfile_url, plugins_dir, "publisher", -1)
 
@@ -46,72 +47,72 @@ class MemInfoCollectorLargeTest(unittest.TestCase):
 
         self.task_file = "{}/examples/tasks/task-mem.json".format(os.getenv("PROJECT_DIR", "snap-plugin-collector-meminfo"))
 
-        log.info("starting snapd")
-        self.binaries.snapd.start()
-        if not self.binaries.snapd.isAlive():
-            self.fail("snapd thread died")
+        log.info("starting snapteld")
+        self.binaries.snapteld.start()
+        if not self.binaries.snapteld.isAlive():
+            self.fail("snapteld thread died")
 
-        log.debug("Waiting for snapd to finish starting")
-        if not self.binaries.snapd.wait():
-            log.error("snapd errors: {}".format(self.binaries.snapd.errors))
-            self.binaries.snapd.kill()
-            self.fail("snapd not ready, timeout!")
+        log.debug("Waiting for snapteld to finish starting")
+        if not self.binaries.snapteld.wait():
+            log.error("snapteld errors: {}".format(self.binaries.snapteld.errors))
+            self.binaries.snapteld.kill()
+            self.fail("snapteld not ready, timeout!")
 
     def test_meminfo_collector_plugin(self):
         # load plugins
         for plugin in self.binaries.get_all_plugins():
-            log.info("snapctl plugin load {}".format(os.path.join(plugin.dir, plugin.name)))
-            loaded = self.binaries.snapctl.load_plugin(plugin)
+            log.info("snaptel plugin load {}".format(os.path.join(plugin.dir, plugin.name)))
+            loaded = self.binaries.snaptel.load_plugin(plugin)
             self.assertTrue(loaded, "{} loaded".format(plugin.name))
 
         # check available metrics, plugins and tasks
-        metrics = self.binaries.snapctl.list_metrics()
-        plugins = self.binaries.snapctl.list_plugins()
-        tasks = self.binaries.snapctl.list_tasks()
+        metrics = self.binaries.snaptel.list_metrics()
+        plugins = self.binaries.snaptel.list_plugins()
+        tasks = self.binaries.snaptel.list_tasks()
         self.assertGreater(len(metrics), 0, "Metrics available {} expected {}".format(len(metrics), 0))
         self.assertEqual(len(plugins), 2, "Plugins available {} expected {}".format(len(plugins), 2))
         self.assertEqual(len(tasks), 0, "Tasks available {} expected {}".format(len(tasks), 0))
 
         # check config policy for metric
-        rules = self.binaries.snapctl.metric_get("/intel/procfs/meminfo/mem_free")
+        rules = self.binaries.snaptel.metric_get("/intel/procfs/meminfo/mem_free")
         self.assertEqual(len(rules), 1, "Rules available {} expected {}".format(len(rules), 1))
 
         # create and list available task
-        log.info("snapctl task create -t {}".format(self.task_file))
-        task_id = self.binaries.snapctl.create_task(self.task_file)
-        tasks = self.binaries.snapctl.list_tasks()
+        log.info("snaptel task create -t {}".format(self.task_file))
+        task_id = self.binaries.snaptel.create_task(self.task_file)
+        tasks = self.binaries.snaptel.list_tasks()
         self.assertEqual(len(tasks), 1, "Tasks available {} expected {}".format(len(tasks), 1))
 
         # check if task hits and fails
-        hits = self.binaries.snapctl.task_hits_count(task_id)
-        fails = self.binaries.snapctl.task_fails_count(task_id)
+        hits = self.binaries.snaptel.task_hits_count(task_id)
+        fails = self.binaries.snaptel.task_fails_count(task_id)
         self.assertGreater(hits, 0, "Task hits {} expected {}".format(hits, ">0"))
         self.assertEqual(fails, 0, "Task fails {} expected {}".format(fails, 0))
 
         # stop task and list available tasks
-        log.info("snapctl task stop {}".format(task_id))
-        stopped = self.binaries.snapctl.stop_task(task_id)
+        log.info("snaptel task stop {}".format(task_id))
+        stopped = self.binaries.snaptel.stop_task(task_id)
         self.assertTrue(stopped, "Task stopped")
-        tasks = self.binaries.snapctl.list_tasks()
+        tasks = self.binaries.snaptel.list_tasks()
         self.assertEqual(len(tasks), 1, "Tasks available {} expected {}".format(len(tasks), 1))
 
         # unload plugin, list metrics and plugins
-        log.info("snapctl plugin unload {}".format(self.binaries.collector))
-        self.binaries.snapctl.unload_plugin(self.binaries.collector)
-        metrics = self.binaries.snapctl.list_metrics()
-        plugins = self.binaries.snapctl.list_plugins()
+        log.info("snaptel plugin unload {}".format(self.binaries.collector))
+        self.binaries.snaptel.unload_plugin(self.binaries.collector)
+        metrics = self.binaries.snaptel.list_metrics()
+        plugins = self.binaries.snaptel.list_plugins()
         self.assertEqual(len(metrics), 0, "Metrics available {} expected {}".format(len(metrics), 0))
         self.assertEqual(len(plugins), 1, "Plugins available {} expected {}".format(len(plugins), 1))
 
-        # check for snapd errors
-        self.assertEqual(len(self.binaries.snapd.errors), 0, "Errors found during snapd execution:\n{}"
-                         .format("\n".join(self.binaries.snapd.errors)))
+        # check for snapteld errors
+        self.assertEqual(len(self.binaries.snapteld.errors), 0, "Errors found during snapteld execution:\n{}"
+                         .format("\n".join(self.binaries.snapteld.errors)))
 
     def tearDown(self):
-        log.info("stopping snapd")
-        self.binaries.snapd.stop()
-        if self.binaries.snapd.isAlive():
-            log.warn("snapd thread did not die")
+        log.info("stopping snapteld")
+        self.binaries.snapteld.stop()
+        if self.binaries.snapteld.isAlive():
+            log.warn("snapteld thread did not die")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary of changes:
- Updated ```snapd``` to ```snapteld``` and ```snapctl``` to ```snaptel``` in documentation
- Updated large tests to use new binaries (```snapteld``` and ```snaptel```)

How to verify it:
- Run ```examples/tasks/run-mock-meminfo.sh```
- Read the documentation

Testing done:
- Ran ```examples/tasks/run-mock-meminfo.sh```
- Ran large test
