### PR TITLE
Migrates to snap-plugin-lib-go and to supported level

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,13 +21,13 @@ Once you're ready to contribute code back to this repo, start with these steps:
 * Clone the fork to `$GOPATH/src/github.com/intelsdi-x/`:
 
     ```
-$ cd "${GOPATH}/src/github.com/intelsdi-x/"
-$ git clone https://github.com/intelsdi-x/snap-plugin-collector-meminfo.git
+        $ cd "${GOPATH}/src/github.com/intelsdi-x/"
+        $ git clone https://github.com/intelsdi-x/snap-plugin-collector-meminfo.git
     ```
 * Create a topic branch for your change and checkout that branch:
 
     ```
-$ git checkout -b some-topic-branch
+        $ git checkout -b some-topic-branch
     ```
 * Make your changes to the code and add tests to cover contributed code.
 * Validate the changes and run the test suite if one is provided.

--- a/METRICS.md
+++ b/METRICS.md
@@ -16,12 +16,14 @@ Namespace | Description
 /intel/procfs/meminfo/cma_free | The size of Contiguous Memory Allocator pages, in bytes, which are not used
 /intel/procfs/meminfo/cma_total | The total size of Contiguous Memory Allocator pages, in bytes
 /intel/procfs/meminfo/commit_limit | The  amount of  memory, in bytes, currently available to be allocated on the system based on the overcommit ratio
-/intel/procfs/meminfo/Committed_as | The amount of memory, in bytes, estimated to complete the workload; this value represents the worst case scenario value, and also includes swap memory
+/intel/procfs/meminfo/committed_as | The amount of memory, in bytes, estimated to complete the workload; this value represents the worst case scenario value, and also includes swap memory
 /intel/procfs/meminfo/direct_map1g | The amount of memory, in bytes, being mapped to 1 G pages
 /intel/procfs/meminfo/direct_map2m | The amount of memory, in bytes, being mapped to 2 MB pages
 /intel/procfs/meminfo/direct_map4k | The amount of memory, in bytes, being mapped to standard 4k pages
 /intel/procfs/meminfo/dirty | The total amount of memory, in bytes, waiting to be written back to the disk.
 /intel/procfs/meminfo/hardware_corrupted | The amount of failed memory in bytes (can only be detected when using ECC RAM).
+/intel/procfs/meminfo/high_free | The amount of memory, in bytes, that is not directly mapped into kernel space.
+/intel/procfs/meminfo/high_total | The total amount of memory, in bytes, that is not directly mapped into kernel space. High memory is for pagecache and userspace.
 /intel/procfs/meminfo/huge_pages_free | The total number of hugepages available for the system
 /intel/procfs/meminfo/huge_pages_rsvd | The number of huge pages for which a commitment to allocate from the pool has been made, but no allocation has yet been made.
 /intel/procfs/meminfo/huge_pages_surp |The number of huge pages in the pool above the value in /proc/sys/vm/nr_hugepages
@@ -31,14 +33,18 @@ Namespace | Description
 /intel/procfs/meminfo/inactive_anon | The amount of anonymous memory, in bytes, that has not been used recently and can be swapped out
 /intel/procfs/meminfo/inactive_file | The amount of  pagecache memory, in bytes, that can be reclaimed without huge performance impact
 /intel/procfs/meminfo/kernel_stack | The amount of memory allocated to kernel stacks in bytes
+/intel/procfs/meminfo/low_free | The amount of memory, in bytes, that is directly mapped into kernel space.
+/intel/procfs/meminfo/low_total | The total amount of memory, in bytes, that is directly mapped into kernel space. It might vary based on the type of kernel used.
 /intel/procfs/meminfo/mapped | The total amount of memory, in bytes, which have been used to map devices, files, or libraries using the mmap command
 /intel/procfs/meminfo/mem_available | The estimated amount of memory, in bytes, which is available for starting new applications without swapping
 /intel/procfs/meminfo/mem_free | The amount of physical RAM, in bytes, left unused by the system (the sum of low_free+high_free)
 /intel/procfs/meminfo/mem_total | Total amount of physical RAM, in bytes
 /intel/procfs/meminfo/mem_used | The amount of physical Ram, in bytes which is used; it equals: mem_total-(mem_free+buffers+cached+slab)
 /intel/procfs/meminfo/mlocked | The total amount of memory, in bytes, which is locked from userspace.
+/intel/procfs/meminfo/mmap_copy | The amount of memory, in bytes, which has been used in copying mmap(). Notice that MMU is required to see this metric.
 /intel/procfs/meminfo/nfs_unstable | The size of NFS pages, in bytes, which are sent to the server, but not yet committed to stable storage
 /intel/procfs/meminfo/page_tables | The total amount of memory, in bytes, dedicated to the lowest page table level.
+/intel/procfs/meminfo/quicklists | The amount of memory, in bytes, consumed by quicklists.
 /intel/procfs/meminfo/sreclaimable | The part of Slab, in bytes, that might be reclaimed, such as caches
 /intel/procfs/meminfo/sunreclaim | The part of Slab, in bytes, that cannot be reclaimed on memory pressure
 /intel/procfs/meminfo/shmem | The total amount of memory, in bytes, which is shared

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
+[![Build Status](https://travis-ci.org/intelsdi-x/snap-plugin-collector-meminfo.svg?branch=master)](https://travis-ci.org/intelsdi-x/snap-plugin-collector-meminfo)
+
 # Snap collector plugin - meminfo
 This plugin collects metrics from /proc/meminfo kernel interface about distribution and utilization of memory.  
 
-It's used in the [snap framework](http://github.com:intelsdi-x/snap).
+It's used in the [snap framework](http://github.com/intelsdi-x/snap).
 
 1. [Getting Started](#getting-started)
   * [System Requirements](#system-requirements)
@@ -13,12 +15,12 @@ It's used in the [snap framework](http://github.com:intelsdi-x/snap).
   * [Roadmap](#roadmap)
 3. [Community Support](#community-support)
 4. [Contributing](#contributing)
-5. [License](#license-and-authors)
+5. [License](#license)
 6. [Acknowledgements](#acknowledgements)
 
 ## Getting Started
 ### System Requirements
-* [golang 1.6+](https://golang.org/dl/)
+* [golang 1.7+](https://golang.org/dl/) - needed only for building
 
 ### Operating systems
 All OSs currently supported by snap:

--- a/examples/tasks/task-mem.json
+++ b/examples/tasks/task-mem.json
@@ -14,7 +14,7 @@
       },
       "config": {
         "/intel/procfs": {
-          "proc_path": "/var/procfs"
+          "proc_path": "/proc"
         }
       },
       "publish": [

--- a/glide.lock
+++ b/glide.lock
@@ -1,68 +1,110 @@
-hash: a5d8527edddbfd61a438bac8ebb8cfc1686f6fe81e3b03eded68d413819ea1ec
-updated: 2016-10-12T14:13:51.127712295+02:00
+hash: 6160a5878025d582dc8876dd4b28fff6ed6087e8af5e1b3315f784b72c2de71b
+updated: 2017-08-17T15:48:21.792574353+02:00
 imports:
-- name: github.com/intelsdi-x/snap
-  version: 14a1611e90f4f94d690e85c6ae58d81a5cf433d0
+- name: github.com/golang/protobuf
+  version: ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e
   subpackages:
-  - control/plugin
-  - control/plugin/cpolicy
-  - control/plugin/encoding
-  - control/plugin/encrypter
-  - core
-  - core/cdata
-  - core/ctypes
-  - core/serror
-  - pkg/ctree
-  - pkg/schedule
-  - scheduler/wmap
+  - proto
+  - ptypes
+  - ptypes/any
+  - ptypes/duration
+  - ptypes/timestamp
+- name: github.com/intelsdi-x/snap-plugin-lib-go
+  version: 4fa1360e35b2f1ebb5fb14a575cc11ecc199c531
+  subpackages:
+  - v1/plugin
+  - v1/plugin/rpc
 - name: github.com/intelsdi-x/snap-plugin-utilities
-  version: 925bafffac36edcfaf4aff937dcb7d3d5659782d
+  version: 3c37e3965f3fc2f24714779d3bae7ba7032b87a9
   subpackages:
-  - config
   - ns
   - str
+- name: github.com/julienschmidt/httprouter
+  version: 975b5c4c7c21c0e3d2764200bf2aa8e34657ae6e
 - name: github.com/mitchellh/mapstructure
-  version: a6ef2f080c66d0a2e94e97cf74f80f772855da63
+  version: d0303fe809921458f417bcf828397a65db30a7e4
 - name: github.com/oleiade/reflections
-  version: 632977f98cd34d217c4b57d0840ec188b3d3dcaf
-- name: github.com/robfig/cron
-  version: 32d9c273155a0506d27cf73dd1246e86a470997e
+  version: 0e86b3c98b2ff33e30c85cfe97d9a63d439fe7eb
 - name: github.com/Sirupsen/logrus
-  version: be52937128b38f1d99787bb476c789e2af1147f1
+  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
+- name: github.com/urfave/cli
+  version: f017f86fccc5a039a98f23311f34fdf78b014f78
+- name: golang.org/x/crypto
+  version: b176d7def5d71bdd214203491f89843ed217f420
+  subpackages:
+  - ssh/terminal
+- name: golang.org/x/net
+  version: 1c05540f6879653db88113bc4a2b70aec4bd491f
+  subpackages:
+  - context
+  - http2
+  - http2/hpack
+  - idna
+  - internal/timeseries
+  - lex/httplex
+  - trace
 - name: golang.org/x/sys
-  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  version: 9f7170bcd8e9f4d3691c06401119c46a769a1e03
   subpackages:
   - unix
-- name: gopkg.in/yaml.v2
-  version: c1cd2254a6dd314c9d73c338c12688c9325d85c6
+- name: golang.org/x/text
+  version: e56139fd9c5bc7244c76116c68e500765bb6db6b
+  subpackages:
+  - secure/bidirule
+  - transform
+  - unicode/bidi
+  - unicode/norm
+- name: google.golang.org/genproto
+  version: 6b7d9516179cd47f4714cfeb0103ad1dede756c4
+  subpackages:
+  - googleapis/rpc/status
+- name: google.golang.org/grpc
+  version: bfaf0423469fc4f95e9eac7e3eec0b2abb46fcca
+  subpackages:
+  - codes
+  - connectivity
+  - credentials
+  - grpclb/grpc_lb_v1
+  - grpclog
+  - internal
+  - keepalive
+  - metadata
+  - naming
+  - peer
+  - stats
+  - status
+  - tap
+  - transport
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: adab96458c51a58dc1783b3335dcce5461522e75
   subpackages:
   - spew
 - name: github.com/gopherjs/gopherjs
-  version: 4b53e1bddba0e2f734514aeb6c02db652f4c6fe8
+  version: 2b1d432c8a82c9bff0b0baffaeb3ec6e92974112
   subpackages:
   - js
 - name: github.com/jtolds/gls
-  version: 8ddce2a84170772b95dd5d576c48d517b22cac63
+  version: 77f18212c9c7edc9bd6a33d383a7b545ce62f064
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/smartystreets/assertions
-  version: 443d812296a84445c202c085f19e18fc238f8250
+  version: 1540c14c9f1bd1abeba90f29762a4c6e50582303
   subpackages:
   - internal/go-render/render
   - internal/oglematchers
 - name: github.com/smartystreets/goconvey
-  version: 995f5b2e021c69b8b028ba6d0b05c1dd500783db
+  version: d4c757aa9afd1e2fc1832aaab209b5794eb336e1
   subpackages:
   - convey
   - convey/gotest
   - convey/reporting
+- name: github.com/smartystreets/logging
+  version: ac3a674540761aa0b4382094ba4795f917e85c7f
 - name: github.com/stretchr/testify
-  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
   - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,18 +1,21 @@
 package: github.com/intelsdi-x/snap-plugin-collector-meminfo
 import:
 - package: github.com/Sirupsen/logrus
+  version: ^1.0.3
+- package: github.com/intelsdi-x/snap-plugin-lib-go
+  subpackages:
+  - v1/plugin
 - package: github.com/intelsdi-x/snap-plugin-utilities
   subpackages:
-  - config
   - ns
 - package: github.com/mitchellh/mapstructure
-- package: github.com/intelsdi-x/snap
-  version: 14a1611e90f4f94d690e85c6ae58d81a5cf433d0
 testImport:
 - package: github.com/smartystreets/goconvey
+  version: ^1.6.2
   subpackages:
   - convey
 - package: github.com/stretchr/testify
+  version: ^1.1.4
   subpackages:
   - assert
   - suite

--- a/main.go
+++ b/main.go
@@ -22,14 +22,15 @@ limitations under the License.
 package main
 
 import (
-	"os"
-
 	"github.com/intelsdi-x/snap-plugin-collector-meminfo/mem"
-	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin"
 )
 
 func main() {
-	plugin.Start(
-		mem.Meta(), mem.New(), os.Args[1],
+	plugin.StartCollector(
+		mem.New(),
+		mem.PluginName,
+		mem.PluginVersion,
+		plugin.ConcurrencyCount(1),
 	)
 }

--- a/mem/mem_test.go
+++ b/mem/mem_test.go
@@ -1,3 +1,5 @@
+// +build small
+
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
@@ -24,10 +26,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/intelsdi-x/snap/control/plugin"
-	"github.com/intelsdi-x/snap/core"
+	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin"
 
-	"github.com/intelsdi-x/snap/core/ctypes"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -110,8 +110,10 @@ func (mps *MemPluginSuite) TestGetMetricTypes() {
 		memPlugin := New()
 
 		Convey("When one wants to get list of available meterics", func() {
-			cfg := plugin.NewPluginConfigType()
-			cfg.AddItem("proc_path", ctypes.ConfigValueStr{Value: "."})
+			cfg := plugin.Config{
+				"proc_path": ".",
+			}
+
 			mts, err := memPlugin.GetMetricTypes(cfg)
 
 			Convey("Then error should not be reported", func() {
@@ -123,7 +125,7 @@ func (mps *MemPluginSuite) TestGetMetricTypes() {
 
 				namespaces := []string{}
 				for _, m := range mts {
-					namespaces = append(namespaces, m.Namespace().String())
+					namespaces = append(namespaces, m.Namespace.String())
 				}
 
 				So(namespaces, ShouldContain, "/intel/procfs/meminfo/cached")
@@ -148,13 +150,15 @@ func (mps *MemPluginSuite) TestCollectMetrics() {
 		memPlugin := New()
 
 		Convey("When one wants to get values for given metric types", func() {
-			cfg := plugin.NewPluginConfigType()
-			cfg.AddItem("proc_path", ctypes.ConfigValueStr{Value: "."})
-			mTypes := []plugin.MetricType{
-				plugin.MetricType{Namespace_: core.NewNamespace("intel", "procfs", "meminfo", "cached"), Config_: cfg.ConfigDataNode},
-				plugin.MetricType{Namespace_: core.NewNamespace("intel", "procfs", "meminfo", "cached_perc"), Config_: cfg.ConfigDataNode},
-				plugin.MetricType{Namespace_: core.NewNamespace("intel", "procfs", "meminfo", "mem_total"), Config_: cfg.ConfigDataNode},
-				plugin.MetricType{Namespace_: core.NewNamespace("intel", "procfs", "meminfo", "mem_used"), Config_: cfg.ConfigDataNode},
+			cfg := plugin.Config{
+				"proc_path": ".",
+			}
+
+			mTypes := []plugin.Metric{
+				plugin.Metric{Namespace: plugin.NewNamespace("intel", "procfs", "meminfo", "cached"), Config: cfg},
+				plugin.Metric{Namespace: plugin.NewNamespace("intel", "procfs", "meminfo", "cached_perc"), Config: cfg},
+				plugin.Metric{Namespace: plugin.NewNamespace("intel", "procfs", "meminfo", "mem_total"), Config: cfg},
+				plugin.Metric{Namespace: plugin.NewNamespace("intel", "procfs", "meminfo", "mem_used"), Config: cfg},
 			}
 
 			metrics, err := memPlugin.CollectMetrics(mTypes)
@@ -168,8 +172,8 @@ func (mps *MemPluginSuite) TestCollectMetrics() {
 
 				stats := map[string]interface{}{}
 				for _, m := range metrics {
-					n := m.Namespace().String()
-					stats[n] = m.Data()
+					n := m.Namespace.String()
+					stats[n] = m.Data
 				}
 
 				assert.Equal(mps.T(), len(metrics), len(stats))


### PR DESCRIPTION
Summary of changes:
- migrates to snap-plugin-lib-go in plugin dependency
- migrates the plugin to supported level (i.a. updating README.md, METRICS.md and exemplary task manifest)
 - updated glide.yaml and glide.lock

Testing done:
- small tests
- manual run the exemplary task manifest


cc: @intelsdi-x/snap-maintainers 

